### PR TITLE
make logging more customizable, and allow saving logs

### DIFF
--- a/command-log-mode.el
+++ b/command-log-mode.el
@@ -48,6 +48,8 @@
 
 (eval-when-compile (require 'cl))
 
+(defvar clm/time-string "%Y-%m-%dT%H:%M:%S"
+  "The string sent to `format-time-string' when command time is logged.")
 (defvar clm/log-command-exceptions*
   '(nil self-insert-command backward-char forward-char
         delete-char delete-backward-char backward-delete-char
@@ -236,7 +238,7 @@ Scrolling up can be accomplished with:
                  (insert
                   (propertize
                    (key-description (this-command-keys))
-                   :time (format-time-string "%Y-%m-%dT%H:%M:%S" (current-time))))
+                   :time  (format-time-string clm/time-string (current-time))))
                  (when (>= (current-column) clm/log-command-indentation)
                    (newline))
                  (move-to-column clm/log-command-indentation t)

--- a/command-log-mode.el
+++ b/command-log-mode.el
@@ -62,7 +62,9 @@
 (add-hook 'post-self-insert-hook 'clm/recent-history)
 
 (defun clm/zap-recent-history ()
-  (unless (eq this-original-command #'self-insert-command)
+  (unless (or (member this-original-command
+		      clm/log-command-exceptions*)
+	      (eq this-original-command #'self-insert-command))
     (setq clm/recent-history-string "")))
 
 (add-hook 'post-command-hook 'clm/zap-recent-history)


### PR DESCRIPTION
1. Allow the user to specify the format of the time string stored on the `:time` property with a new variable `clm/time-string`.
2. Allow optional logging of recent text via a `clm/log-text` variable and support functions attaching to `post-self-insert-hook` and `post-command-hook`
3. Add function `clm/save-command-log` to save recently entered commands to today's log, using a sensible format.

Sample log:

```
H	   self-insert-command [35 times] 
[text: Here is an example of how it works.]
RET	   newline
P	   self-insert-command [12 times] 
[text: Pretty nice.]
RET	   newline
I	   self-insert-command [31 times] 
[text: If you make mistakes when typin]
DEL	   backward-delete-char-untabify [2 times]
o	   self-insert-command [42 times] 
[text: oing you have to read the lines separetly.]
<C-backspace>
	   (lambda nil (interactive) (kill-sexp -1))
s	   self-insert-command [11 times] 
[text: separately.]
RET	   newline
C-x o	   other-window [2 times]
```