### PR TITLE
Make command log colorful

### DIFF
--- a/command-log-mode.el
+++ b/command-log-mode.el
@@ -102,6 +102,16 @@ Frequently used non-interesting commands (like cursor movements) should be put h
 (defgroup command-log nil
   "Customization for the command log.")
 
+(defface command-log-key
+  '((t (:foreground "cyan")))
+  "Face for keys in command log."
+  :group 'command-log)
+
+(defface command-log-command
+  '((t (:foreground "pale green")))
+  "Face for commands in command log."
+  :group 'command-log)
+
 (defcustom command-log-mode-auto-show nil
   "Show the command-log window or frame automatically."
   :group 'command-log
@@ -266,11 +276,13 @@ Scrolling up can be accomplished with:
                  (insert
                   (propertize
                    (key-description (this-command-keys))
-                   :time  (format-time-string clm/time-string (current-time))))
+                   :time  (format-time-string clm/time-string (current-time))
+                   'face 'command-log-key))
                  (when (>= (current-column) clm/log-command-indentation)
                    (newline))
                  (move-to-column clm/log-command-indentation t)
-                 (princ cmd current)
+                 (insert (propertize (format "%s" cmd)
+                                     'face 'command-log-command))
                  (newline)
                  (setq clm/last-keyboard-command cmd)))
           (clm/scroll-buffer-window current))))))


### PR DESCRIPTION
Add two faces - one for keys and one for commands.
You might want to adjust the faces' default values. They work fine with the theme I'm using, but not with the default emacs theme.

Implements #7 
