### PR TITLE
Add clm/log-repeat

### DIFF
--- a/command-log-mode.el
+++ b/command-log-mode.el
@@ -51,6 +51,9 @@
 (defvar clm/log-text t
   "A non-nil setting means text will be saved to the command log.")
 
+(defvar clm/log-repeat nil
+  "A nil setting means repetitions of the same command are merged into the single log line.")
+
 (defvar clm/recent-history-string ""
   "This string will hold recently typed text.")
 
@@ -248,7 +251,7 @@ Scrolling up can be accomplished with:
       (clm/with-command-log-buffer
         (let ((current (current-buffer)))
           (goto-char (point-max))
-          (cond ((eq cmd clm/last-keyboard-command)
+          (cond ((and (not clm/log-repeat) (eq cmd clm/last-keyboard-command))
                  (incf clm/command-repetitions)
                  (save-match-data
                    (when (and (> clm/command-repetitions 1)
@@ -259,7 +262,8 @@ Scrolling up can be accomplished with:
                  (princ (1+ clm/command-repetitions) current)
                  (insert " times]"))
                 (t ;; (message "last cmd: %s cur: %s" last-command cmd)
-		 (when clm/log-text
+                 ;; showing accumulated text with interleaved key presses isn't very useful
+		 (when (and clm/log-text (not clm/log-repeat))
 		   (if (eq clm/last-keyboard-command 'self-insert-command)
 		       (insert "[text: " clm/recent-history-string "]\n")))
                  (setq clm/command-repetitions 0)


### PR DESCRIPTION
The variable controls if command-log-mode merges multiple repetitions of
the same command into the single line. By default, it does.

Not merging repeated commands is useful if you want to analyze timing
stats later.