### PR TITLE
Visual and convenience

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,6 +6,28 @@ Show event history and command history of some or all buffers.
 
 [[https://github.com/lewang/command-log-mode/raw/master/screenshot1.png]]
 
+** How do I use it?
+
+   Use the =clm/toggle-command-log-buffer= command.  This use-package
+   configuration will configure this command to log globally, including the
+   mininbuffer, and to disable the global minor mode when you toggle while the
+   buffer is visible.  Customize the =command-log= group for more options.
+
+   #+begin_src elisp
+
+     (use-package command-log-mode
+        :custom
+        (command-log-mode-window-font-size 20)
+        (command-log-mode-open-log-turns-on-mode t "Show buffer enables mode")
+        (command-log-mode-close-log-turns-off-mode t "Show buffer disables mode")
+        (command-log-mode-is-global "Auto-enable with global minor mode (including minibuffer)")
+        :config
+
+        ;; Be chatty.  Show everything besides self-insert-command
+        (setq clm/log-command-exceptions* '(self-insert-command)))
+
+   #+end_src
+
 ** Where it from?
 
 This package is a fork of [[http://www.foldr.org/~michaelw/emacs/mwe-log-commands.el][mwe-log-commands.el]] by Michael Weber <michaelw@foldr.org>

--- a/command-log-mode.el
+++ b/command-log-mode.el
@@ -105,7 +105,7 @@ Frequently used non-interesting commands (like cursor movements) should be put h
 (defgroup command-log nil
   "Customization for the command log.")
 
-(defcustom command-log-mode-auto-show nil
+(defcustom command-log-mode-auto-show t
   "Show the command-log window or frame automatically."
   :group 'command-log
   :type 'boolean)
@@ -127,17 +127,17 @@ Frequently used non-interesting commands (like cursor movements) should be put h
           (const :tag "No key" nil)
           (key-sequence "C-c o"))) ;; this is not right though it works for kbd
 
-(defcustom command-log-mode-open-log-turns-on-mode nil
+(defcustom command-log-mode-open-log-turns-on-mode t
   "Does opening the command log turn on the mode?"
   :group 'command-log
   :type 'boolean)
 
-(defcustom command-log-mode-close-log-turns-off-mode nil
+(defcustom command-log-mode-close-log-turns-off-mode t
   "Does closing the command log turn off the mode?"
   :group 'command-log
   :type 'boolean)
 
-(defcustom command-log-mode-is-global nil
+(defcustom command-log-mode-is-global t
   "Does turning on command-log-mode happen globally?"
   :group 'command-log
   :type 'boolean)

--- a/command-log-mode.el
+++ b/command-log-mode.el
@@ -132,6 +132,11 @@ Frequently used non-interesting commands (like cursor movements) should be put h
   :group 'command-log
   :type 'boolean)
 
+(defcustom command-log-mode-close-log-turns-off-mode nil
+  "Does closing the command log turn off the mode?"
+  :group 'command-log
+  :type 'boolean)
+
 (defcustom command-log-mode-is-global nil
   "Does turning on command-log-mode happen globally?"
   :group 'command-log
@@ -207,16 +212,23 @@ If ARG is Non-nil, the existing command log buffer is cleared."
   (when (and command-log-mode-open-log-turns-on-mode
              (not command-log-mode))
     (if command-log-mode-is-global
-        (global-command-log-mode)
-        (command-log-mode)))
+        (global-command-log-mode t)
+      (command-log-mode t)))
+
   (with-current-buffer
       (setq clm/command-log-buffer
             (get-buffer-create " *command-log*"))
     (let ((win (get-buffer-window (current-buffer))))
       (if (windowp win)
-          (clm/close-command-log-buffer)
-          ;; Else open the window
-          (clm/open-command-log-buffer arg)))))
+          (progn
+            (when (and command-log-mode-close-log-turns-off-mode
+                       (command-log-mode))
+              (if command-log-mode-is-global
+                  (global-command-log-mode nil)
+                (command-log-mode nil)))
+            (clm/close-command-log-buffer))
+        ;; Else open the window
+        (clm/open-command-log-buffer arg)))))
 
 (defun clm/scroll-buffer-window (buffer &optional move-fn)
   "Updates `point' of windows containing BUFFER according to MOVE-FN.

--- a/command-log-mode.el
+++ b/command-log-mode.el
@@ -258,23 +258,31 @@ Scrolling up can be accomplished with:
                               (search-backward "[" (line-beginning-position -1) t))
                      (delete-region (point) (line-end-position))))
                  (backward-char) ; skip over either ?\newline or ?\space before ?\[
-                 (insert " [")
-                 (princ (1+ clm/command-repetitions) current)
-                 (insert " times]"))
+                 (insert (propertize (concat
+                                      " ["
+                                      (number-to-string (1+ clm/command-repetitions))
+                                      " times]")
+                                     'face 'font-lock-doc-face)))
                 (t ;; (message "last cmd: %s cur: %s" last-command cmd)
                  ;; showing accumulated text with interleaved key presses isn't very useful
-		 (when (and clm/log-text (not clm/log-repeat))
-		   (if (eq clm/last-keyboard-command 'self-insert-command)
-		       (insert "[text: " clm/recent-history-string "]\n")))
+        	 (when (and clm/log-text (not clm/log-repeat))
+        	   (if (eq clm/last-keyboard-command 'self-insert-command)
+        	       (insert (propertize
+                                (concat "[text: " clm/recent-history-string "]\n")
+                                'face 'font-lock-doc-face))))
                  (setq clm/command-repetitions 0)
                  (insert
                   (propertize
                    (key-description (this-command-keys))
-                   :time  (format-time-string clm/time-string (current-time))))
+                   :time  (format-time-string clm/time-string (current-time))
+                   'face 'font-lock-keyword-face))
                  (when (>= (current-column) clm/log-command-indentation)
                    (newline))
                  (move-to-column clm/log-command-indentation t)
-                 (princ (if (byte-code-function-p cmd) "<bytecode>" cmd) current)
+                 (insert
+                  (propertize
+                   (if (byte-code-function-p cmd) "<bytecode>" (symbol-name cmd))
+                   'face 'font-lock-function-name-face))
                  (newline)
                  (setq clm/last-keyboard-command cmd)))
           (clm/scroll-buffer-window current))))))


### PR DESCRIPTION
 Log now is colored based on user's current font-locking for syntax highlighting. 
 
I made the defaults configure the toggle command to "actually do something" and added a corresponding configuration example so that most out-of-the-box usage is fine for casting or replacing lossage.

Toggle behavior was made capable of cleaning itself up.

![image](https://user-images.githubusercontent.com/73710933/136575757-8aa40587-cea7-4968-9ff8-5114ae676332.png)
